### PR TITLE
Several enhancements to emulation functions

### DIFF
--- a/APLSource/A2K/GLOBALTRAP.aplf
+++ b/APLSource/A2K/GLOBALTRAP.aplf
@@ -1,18 +1,23 @@
- EXPR←GLOBALTRAP;⎕TRAP;Z;interrupt;en;where
- ⎕TRAP←0 'S' ⍝ Avoid loops
+ EXPR←GLOBALTRAP;⎕TRAP;en;interrupt
+ ⎕TRAP←(0 1000) 'S' ⍝ Avoid loops
 
- interrupt←(en←⎕DMX.EN)≥1000
+ :If interrupt←(en←⎕DMX.EN)≥1000
+    :If 2=⎕NC 'DEBUG_INTERRUPTS'
+       :AndIf 3=⎕NC DEBUG_INTERRUPTS
+           EXPR←⍎DEBUG_INTERRUPTS
+           →0
+    :EndIf
+ :EndIf
+
  :If 0=#.⎕NC '∆QELX' ⋄ #.∆QELX←'⎕DM' ⋄ :EndIf
  :If 0=#.⎕NC '∆QALX' ⋄ #.∆QALX←'⎕DM' ⋄ :EndIf
  EXPR←(1+interrupt)⊃#.(∆QELX ∆QALX)
 
  :If EXPR≢'⎕DM'
-     ⎕←⊃⎕DMX.DM
-     ⎕←'GLOBALTRAP caught event ',(⍕en),', executing ''',EXPR,''''
-     ⍝ Don't need manual intervention any more, remove the following commented lines after a wee bit more testing
-     ⍝ :If 'stop'≡⎕C Z←⍞~' '
-     ⍝     ∘∘∘
-     ⍝ :EndIf
+     :If 2=⎕NC 'DISPLAY_ERRORS'
+     :AndIf 3=⎕NC DISPLAY_ERRORS
+         ⍎DISPLAY_ERRORS,' EXPR'
+     :EndIf
  :Else
      EXPR←'⎕←⍪⎕DM'
  :EndIf

--- a/APLSource/A2K/∆NA.aplf
+++ b/APLSource/A2K/∆NA.aplf
@@ -1,5 +1,7 @@
-R←X ∆NA Y;⎕TRAP
-⎕TRAP←0 'S'
-#.⎕FX ('R←',Y,' Y') ('∘∘∘ ⍝ ',X)
-⎕←'⎕NA: ',Y,' = ',X
-R←1
+R←X ∆NA Y
+:If 0=⎕NC 'X'
+:OrIf 0=≢X    ⍝ No or empty left argument
+    R←3.6=(1⊃⎕RSI).⎕NC ⊂Y
+:Else
+    'Dyadic ⎕NA not emulated' ⎕SIGNAL 11
+:EndIf

--- a/APLSource/A2K/∆VGET.aplf
+++ b/APLSource/A2K/∆VGET.aplf
@@ -1,10 +1,10 @@
  ∆VGET←{
      ⍺←1
      Exec←(2147483647×~⍺)∘(⍬⍴⎕RSI).(86⌶)
-     (varname default)←w←⊆⍵
+     (varname default)←w←{0=10|⎕DR ⍵:⍵ 0 ⋄ 2≠≢⍵: 2↑(⊆⍵),⊂0 ⋄ ⍵} ⍵
      ¯1=⎕NC varname:⎕SIGNAL 11
      isvar←2=Exec'⎕NC ''',varname,''''
      isvar:Exec varname
-     2=≢w:⊃⊢/⍵
+     2=≢w:default
      ⎕SIGNAL 6
  }

--- a/APLSource/A2K/∆XLIB.aplf
+++ b/APLSource/A2K/∆XLIB.aplf
@@ -5,12 +5,13 @@
  :AndIf 1=1 ⎕NINFO X ⍝ dir
      X,←'/*'
  :EndIf
- :If 0∊⍴R←↑⊃⎕NINFO⍠1⊢X
-     :If ∨/'?*'∊X
+ :If 0∊⍴R←↑⎕NINFO⍠1⊢X
+     :If ∨/'?*'∊∊X
          R←0 0⍴' '
      :Else
          'XFHOST ERROR FindFirstFile 1 0 3 The system cannot find the path specified.'⎕SIGNAL 22
      :EndIf
  :Else
+     R←↑∊¨1↓¨⎕NPARTS R
      R←R[⍋R;]
  :EndIf


### PR DESCRIPTION
This PR / Branch started out as a single update to the VGET function, but has evolved to contain several fixes to problems discovered over Easter 2025:

- VGET needs to handle scalar variable names e.g. (VGET 'x' 0)
- XLIB should return file names only, without a leading directory name
- NA needs to return 1 if the function name represents a NA'd function, when called monadically or with an empty left argument. When called dyadically, it should signal an error rather than "destroy" an existing function with the name in the right argument.
- GLOBALTRAP has been extended with "exits" controlled by the existence of variables DEBUG_INTERRUPTS (called to handle user interrupts) or DISPLAY_ERRORS (controls the logging to the session of trapped errors - for diagnostic purposes)
